### PR TITLE
Layout/signup layout

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -9,7 +9,8 @@
       "en": "English",
       "kr": "한국어"
     },
-    "signin": "Sign In"
+    "signin": "Sign In",
+    "signout": "Sign Out"
   },
   "form": {
     "email": {

--- a/public/locales/kr/common.json
+++ b/public/locales/kr/common.json
@@ -9,7 +9,8 @@
       "en": "English",
       "kr": "한국어"
     },
-    "signin": "로그인"
+    "signin": "로그인",
+    "signout": "로그아웃"
   },
   "form": {
     "email": {

--- a/src/components/layout/SignupLayout/index.tsx
+++ b/src/components/layout/SignupLayout/index.tsx
@@ -2,10 +2,11 @@ import type { ReactNode } from 'react';
 import Link from 'next/link';
 import { useTranslation } from 'next-i18next';
 import NetflixLogo from '@assets/netflix/top-logo.svg'
-import { theme } from '../ui/theme';
-import ConditionalRender from '../ui/utils/ConditionalRender';
-import BaseLayout from './BaseLayout'
-import { BodyContentShellCss, BodyLayoutCss, FooterContentShellCss, FooterLayoutCss, HeaderBorderCss, HeaderDefaultStyleCss, HeaderLinkStyleCss, HeaderLoginLinkStyleCss, } from './styles/SignupLayoutStyle';
+import SignInOutBtn from '../../ui/Button/SignInOutBtn';
+import { theme } from '../../ui/theme';
+import ConditionalRender from '../../ui/utils/ConditionalRender';
+import BaseLayout from '../BaseLayout'
+import { BodyContentShellCss, BodyLayoutCss, FooterContentShellCss, FooterLayoutCss, HeaderBorderCss, HeaderDefaultStyleCss, HeaderLinkStyleCss, HeaderLoginLinkStyleCss } from '../styles/SignupLayoutStyle';
 interface SignupLayoutProps {
   isDark?: boolean
   children?: ReactNode
@@ -20,9 +21,11 @@ export default function SignupLayout({ isDark, children, withShell }: SignupLayo
       <Link css={HeaderLinkStyleCss} href="/">
         <NetflixLogo />
       </Link>
-      <Link css={HeaderLoginLinkStyleCss} href="/login">
-        {t('head.signin')}
-      </Link>
+      <SignInOutBtn
+        css={HeaderLoginLinkStyleCss}
+        signInText={t('head.signin')}
+        signOutText={t('head.signout')}
+      />
     </div>
     {/* BODY */}
     {/* TODO: need to add animation https://dev.to/joseph42a/nextjs-page-transition-with-framer-motion-33dg */}

--- a/src/components/pages/Home/index.tsx
+++ b/src/components/pages/Home/index.tsx
@@ -2,10 +2,11 @@ import type { NextPageWithLayout } from '@/pages/_app';
 import { useTranslation } from 'next-i18next'
 import LanguageSelect from '@/components/i18n/LanguageSelect';
 import BaseLayout from '@/components/layout/BaseLayout';
+import SignInOutBtn from '@/components/ui/Button/SignInOutBtn';
 import EmailSubmitForm from './component/EmailSubmitForm';
 import { HeroBottom, HeroBottomLine, HeroBottomMargin } from './styles/HeroBottom';
 import { HeroContent, HeroContentBg, HeroContentBgShadow, HeroContentDetail, HeroContentDetailShell, HeroContentDetailContentLayout, HeroContentShell } from './styles/HeroContent';
-import { HeroHead, HeroHeadContent, HeroHeadLayer, HeroHeadLogo, HeroHeadRightSide, HeroHeadSigninLink } from './styles/HeroHead';
+import { HeroHead, HeroHeadContent, HeroHeadLayer, HeroHeadLogo, HeroHeadRightSide, HeroHeadSigninOutLinkCss } from './styles/HeroHead';
 import { HeroDescrpition1, HeroSection, HeroTitle } from './styles/HeroSection';
 
 const Home: NextPageWithLayout = () => {
@@ -21,9 +22,11 @@ const Home: NextPageWithLayout = () => {
             <HeroHeadRightSide>
               <div></div>
               <LanguageSelect />
-              <HeroHeadSigninLink href="/signin">
-                {t('head.signin')}
-              </HeroHeadSigninLink>
+              <SignInOutBtn
+                css={HeroHeadSigninOutLinkCss}
+                signInText={t('head.signin')}
+                signOutText={t('head.signout')}
+              />
             </HeroHeadRightSide>
           </HeroHeadContent>
         </HeroHeadLayer>

--- a/src/components/pages/Home/styles/HeroHead.ts
+++ b/src/components/pages/Home/styles/HeroHead.ts
@@ -1,5 +1,5 @@
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import Link from 'next/link';
 import { MediaPoint } from '@/components/styled/layout';
 import { DefaultButtonCss, RedButtonCss } from '@/components/ui/Button/ButtonStyle';
 import { TextDisplayCss } from '@/components/ui/Font/TextDisplayStyle';
@@ -56,7 +56,7 @@ export const HeroHeadRightSide = styled.div([{
   columnGap: '12px',
 }])
 
-export const HeroHeadSigninLink = styled(Link)([
+export const HeroHeadSigninOutLinkCss = css([
   TextDisplayCss,
   DefaultButtonCss,
   RedButtonCss.color,

--- a/src/components/ui/Button/SignInOutBtn.tsx
+++ b/src/components/ui/Button/SignInOutBtn.tsx
@@ -1,3 +1,4 @@
+import type { AnchorHTMLAttributes } from 'react';
 import Link from 'next/link';
 import { useMemo } from 'react';
 import ConditionalRender from '@/components/ui/utils/ConditionalRender';
@@ -8,16 +9,16 @@ interface SignInOutBtnProps {
   signOutText: string
 }
 
-export default function SignInOutBtn({ signInText, signOutText, className }: SignInOutBtnProps & CssProps) {
+export default function SignInOutBtn({ signInText, signOutText, ...props }: SignInOutBtnProps & Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'onClick' | 'href'> & CssProps) {
   const { accessToken, removeJWT } = useJWTs()
   const hasSignined = useMemo(() => Boolean(accessToken), [accessToken])
   return <ConditionalRender.Boolean
     condition={hasSignined}
     render={{
-      true: <Link className={className} onClick={removeJWT} href="/">
+      true: <Link {...props} onClick={removeJWT} href="/">
         {signOutText}
       </Link>,
-      false: <Link className={className} href="/signin">
+      false: <Link {...props} href="/signin">
         {signInText}
       </Link>
     }}

--- a/src/components/ui/Button/SignInOutBtn.tsx
+++ b/src/components/ui/Button/SignInOutBtn.tsx
@@ -1,0 +1,25 @@
+import Link from 'next/link';
+import { useMemo } from 'react';
+import ConditionalRender from '@/components/ui/utils/ConditionalRender';
+import useJWTs from '@/hooks/account/useJWTs';
+
+interface SignInOutBtnProps {
+  signInText: string
+  signOutText: string
+}
+
+export default function SignInOutBtn({ signInText, signOutText, className }: SignInOutBtnProps & CssProps) {
+  const { accessToken, removeJWT } = useJWTs()
+  const hasSignined = useMemo(() => Boolean(accessToken), [accessToken])
+  return <ConditionalRender.Boolean
+    condition={hasSignined}
+    render={{
+      true: <Link className={className} onClick={removeJWT} href="/">
+        {signOutText}
+      </Link>,
+      false: <Link className={className} href="/signin">
+        {signInText}
+      </Link>
+    }}
+  />
+}

--- a/src/hooks/account/useJWTs.ts
+++ b/src/hooks/account/useJWTs.ts
@@ -1,0 +1,22 @@
+import { useAtom } from 'jotai';
+import { accessTokenAtom, refreshTokenAtom } from '@/state/Token';
+
+interface UpdateJWTParams {
+  accessToken: string
+  refreshToken: string
+}
+
+export default function useJWTs() {
+  const [accessToken, setAccessToken] = useAtom(accessTokenAtom)
+  const [, setRefreshToken] = useAtom(refreshTokenAtom)
+  const updateJWT = ({ accessToken, refreshToken }: UpdateJWTParams) => {
+    setAccessToken(accessToken)
+    setRefreshToken(refreshToken)
+  }
+  const removeJWT = () => updateJWT({ accessToken: '', refreshToken: '' })
+  return {
+    accessToken,
+    updateJWT,
+    removeJWT
+  }
+}


### PR DESCRIPTION
### 작업 내용
- 회원 로그아웃 구현

### 추가된 사항
- jwt 관리 훅 추가
- signinout btn 추가

### 수정한 사항
- SignupLayout의 signin btn 교체
- main 페이지의 signin btn 교체

### 시도하본 요소
> 
